### PR TITLE
carbon-apimgt dependency error after v6.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,14 @@
     </repositories>
 
     <properties>
-        <carbon.apimgt.version>[6.4.211,7.0.0]</carbon.apimgt.version>
+        <carbon.apimgt.version>6.4.50</carbon.apimgt.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <carbon.kernel.version>4.4.35</carbon.kernel.version>
         <powermock.version>1.7.4</powermock.version>
         <mockito.all.version>1.10.19</mockito.all.version>
         <json-simple.wso2.version>1.1.wso2v1</json-simple.wso2.version>
         <carbon.governance.version>4.7.29</carbon.governance.version>
-        <synapse.version>2.1.7-wso2v10</synapse.version>
+        <synapse.version>2.1.7-wso2v80</synapse.version>
     </properties>
 
     <build>


### PR DESCRIPTION
As the handler uses carbon apimgt as a dependency, version range does not work after 6.4.232 because from 6.5.0, carbon kernal version changes from 4.4 to 4.5. Therefore carbon apimgt version is set to fix value to work with APIM 2.6.0.