### PR TITLE
Added support to disable certificate validation and changed the ASE payload when the resource is unauthenticated

### DIFF
--- a/DEVELOPER_GUIDE_NEW.md
+++ b/DEVELOPER_GUIDE_NEW.md
@@ -234,8 +234,8 @@ Do not update the already existing execution for the publish event. Add a new ex
     api-manager.xml after the if condition of ApplyForAllAPIs.
     
     ```
-   {% if apim.ai_security.validate_certs is defined %}
-   <ValidateCerts>{{apim.ai_security.validate_certs}}</ValidateCerts>
+   {% if apim.ai_security.skip_cert_validation is defined %}
+   <SkipCertValidation>{{apim.ai_security.skip_cert_validation}}</SkipCertValidation>
    {% endif %}
    ```
 
@@ -414,7 +414,7 @@ Add the required configurations to the  <APIM_HOME>/repository/conf/deployment.t
    ```
     [apim.ai_security]
     apply_for_all = false
-    validate_certs = true
+    skip_cert_validation = false
     cash_expiry_time = 15
     data_publisher.max_per_route = 500
     data_publisher.max_open_connections = 200
@@ -551,7 +551,7 @@ Follow the instructions below to change a password that you had previously encry
 | ---------------- | ----------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | operation_mode   | (String)<ul><li>async</li><li>sync</li><li>hybrid</li></ul> | sync         | The operation mode. <ul><li>Asynchronous mode -  async</li><li>Synchronous mode - sync</li><li>Hybrid mode - hybrid</li></ul> |
 | apply_for_all    | (Boolean)                                                   | true         | Apply Ping Intelligence for all APIs published.                                                                               |
-| validate_certs   | (Boolean)                                                   | true         | Validate the certificates of ASE and Management endpoint or not                                                               |
+| skip_cert_validation   | (Boolean)                                             | false        | Validate the certificates of ASE and Management endpoint or not                                                               |
 | cash_expiry_time | (Integer)                                                   | 15           | Cache Expiry time in minutes.                                                                                                 |
 
 #### APISecurityEnforcer - ASE configurations

--- a/DEVELOPER_GUIDE_NEW.md
+++ b/DEVELOPER_GUIDE_NEW.md
@@ -229,6 +229,15 @@ Do not update the already existing execution for the publish event. Add a new ex
     ```
     <BackupEndPoint>{{apim.ai_security.backup_sideband_request_endpoint}}</BackupEndPoint>
     ```
+   
+   If you want to disable certificate validation of both ASE and Management endpoints, add the following line in the
+    api-manager.xml after the if condition of ApplyForAllAPIs.
+    
+    ```
+   {% if apim.ai_security.validate_certs is defined %}
+   <ValidateCerts>{{apim.ai_security.validate_certs}}</ValidateCerts>
+   {% endif %}
+   ```
 
 ### For the API Publisher
 
@@ -405,6 +414,7 @@ Add the required configurations to the  <APIM_HOME>/repository/conf/deployment.t
    ```
     [apim.ai_security]
     apply_for_all = false
+    validate_certs = true
     cash_expiry_time = 15
     data_publisher.max_per_route = 500
     data_publisher.max_open_connections = 200
@@ -541,6 +551,7 @@ Follow the instructions below to change a password that you had previously encry
 | ---------------- | ----------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | operation_mode   | (String)<ul><li>async</li><li>sync</li><li>hybrid</li></ul> | sync         | The operation mode. <ul><li>Asynchronous mode -  async</li><li>Synchronous mode - sync</li><li>Hybrid mode - hybrid</li></ul> |
 | apply_for_all    | (Boolean)                                                   | true         | Apply Ping Intelligence for all APIs published.                                                                               |
+| validate_certs   | (Boolean)                                                   | true         | Validate the certificates of ASE and Management endpoint or not                                                               |
 | cash_expiry_time | (Integer)                                                   | 15           | Cache Expiry time in minutes.                                                                                                 |
 
 #### APISecurityEnforcer - ASE configurations

--- a/DEVELOPER_GUIDE_OLD.md
+++ b/DEVELOPER_GUIDE_OLD.md
@@ -400,6 +400,7 @@ Add the required configurations to the  <APIM_HOME>/repository/conf/api-manager.
 
     <AISecurityHandler>
         <ApplyForAllAPIs>false</ApplyForAllAPIs>
+        <ValidateCerts>True</ValidateCerts>
         <CacheExpiryTime>15</CacheExpiryTime>
         <DataPublisher>
            <MaxPerRoute>500</MaxPerRoute>
@@ -554,6 +555,7 @@ Follow the instructions below to change a password that you had previously encry
 | --------------- | ----------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | OperationMode   | (String)<ul><li>async</li><li>sync</li><li>hybrid</li></ul> | sync         | The operation mode. <ul><li>Asynchronous mode -  async</li><li>Synchronous mode - sync</li><li>Hybrid mode - hybrid</li></ul> |
 | ApplyForAllAPIs | (Boolean)                                                   | true         | Apply Ping Intelligence for all APIs published.                                                                               |
+| ValidateCerts   | (Boolean)                                                   | true         | Validate the certificates of ASE and Management endpints or not                                                               |
 | CacheExpiryTime | (Integer)                                                   | 15           | Cache Expiry time in minutes.                                                                                                 |
 
 #### APISecurityEnforcer - ASE configurations

--- a/DEVELOPER_GUIDE_OLD.md
+++ b/DEVELOPER_GUIDE_OLD.md
@@ -400,7 +400,7 @@ Add the required configurations to the  <APIM_HOME>/repository/conf/api-manager.
 
     <AISecurityHandler>
         <ApplyForAllAPIs>false</ApplyForAllAPIs>
-        <ValidateCerts>True</ValidateCerts>
+        <SkipCertValidation>False</SkipCertValidation>
         <CacheExpiryTime>15</CacheExpiryTime>
         <DataPublisher>
            <MaxPerRoute>500</MaxPerRoute>
@@ -555,7 +555,7 @@ Follow the instructions below to change a password that you had previously encry
 | --------------- | ----------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | OperationMode   | (String)<ul><li>async</li><li>sync</li><li>hybrid</li></ul> | sync         | The operation mode. <ul><li>Asynchronous mode -  async</li><li>Synchronous mode - sync</li><li>Hybrid mode - hybrid</li></ul> |
 | ApplyForAllAPIs | (Boolean)                                                   | true         | Apply Ping Intelligence for all APIs published.                                                                               |
-| ValidateCerts   | (Boolean)                                                   | true         | Validate the certificates of ASE and Management endpints or not                                                               |
+| SkipCertValidation   | (Boolean)                                              | false        | Validate the certificates of ASE and Management endpints or not                                                               |
 | CacheExpiryTime | (Integer)                                                   | 15           | Cache Expiry time in minutes.                                                                                                 |
 
 #### APISecurityEnforcer - ASE configurations

--- a/ai-security-config.xml
+++ b/ai-security-config.xml
@@ -33,6 +33,9 @@ configuration will be used.-->
     <!--Cache Expiry time in minutes.-->
     <CacheExpiryTime>15</CacheExpiryTime>
 
+    <!--Validate the certificates of ASE and Management endpoints-->
+    <ValidateCerts>True</ValidateCerts>
+
     <!--Ping ASE related configuration used by the feature.
     API Security Enforcer is used to validate and authenticate users against the request metadata.
     Without this configuration, feature will not work.-->

--- a/ai-security-config.xml
+++ b/ai-security-config.xml
@@ -33,8 +33,8 @@ configuration will be used.-->
     <!--Cache Expiry time in minutes.-->
     <CacheExpiryTime>15</CacheExpiryTime>
 
-    <!--Validate the certificates of ASE and Management endpoints-->
-    <ValidateCerts>True</ValidateCerts>
+    <!--Skip the Certificate Validation of ASE and Management endpoints-->
+    <SkipCertValidation>False</SkipCertValidation>
 
     <!--Ping ASE related configuration used by the feature.
     API Security Enforcer is used to validate and authenticate users against the request metadata.

--- a/deployment.toml
+++ b/deployment.toml
@@ -6,6 +6,7 @@
 [apim.ai_security]
 operation_mode = "MODE"
 apply_for_all = false
+validate_certs = false
 cash_expiry_time = 15
 sideband_request_endpoint = "ASE_SIDEBAND_REQUEST_ENDPOINT"
 backup_sideband_request_endpoint = "BACKUP_ASE_SIDEBAND_REQUEST_ENDPOINT"
@@ -31,6 +32,9 @@ limit_transport_headers.header3 = "Header3"
 #operation_mode = "MODE"
 
 #Apply Ping Intelligence for all APIs published from Api Manager
+#apply_for_all = false
+
+#Whether to validate the certificates of ASE and Management endpoint or not
 #apply_for_all = false
 
 #Cache Expiry time in minutes.

--- a/deployment.toml
+++ b/deployment.toml
@@ -6,7 +6,7 @@
 [apim.ai_security]
 operation_mode = "MODE"
 apply_for_all = false
-validate_certs = false
+skip_cert_validation = false
 cash_expiry_time = 15
 sideband_request_endpoint = "ASE_SIDEBAND_REQUEST_ENDPOINT"
 backup_sideband_request_endpoint = "BACKUP_ASE_SIDEBAND_REQUEST_ENDPOINT"
@@ -35,7 +35,7 @@ limit_transport_headers.header3 = "Header3"
 #apply_for_all = false
 
 #Whether to validate the certificates of ASE and Management endpoint or not
-#apply_for_all = false
+#skip_cert_validation = false
 
 #Cache Expiry time in minutes.
 #cash_expiry_time = 15

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public class AISecurityHandlerConfig {
 
     private boolean applyForAllAPIs = true;
+    private boolean validateCerts = true;
     private String mode = AISecurityHandlerConstants.SYNC_MODE_STRING;
     private int cacheExpiryTime = 15;
     private AISecurityHandlerConfig.AseConfig aseConfig;
@@ -59,6 +60,16 @@ public class AISecurityHandlerConfig {
 
     public void setCacheExpiryTime(int cacheExpiryTime) {
         this.cacheExpiryTime = cacheExpiryTime;
+    }
+
+    public boolean isValidateCerts() {
+
+        return validateCerts;
+    }
+
+    public void setValidateCerts(boolean validateCerts) {
+
+        this.validateCerts = validateCerts;
     }
 
     public AISecurityHandlerConfig.AseConfig getAseConfig() {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public class AISecurityHandlerConfig {
 
     private boolean applyForAllAPIs = true;
-    private boolean validateCerts = true;
+    private boolean skipCertValidation = false;
     private String mode = AISecurityHandlerConstants.SYNC_MODE_STRING;
     private int cacheExpiryTime = 15;
     private AISecurityHandlerConfig.AseConfig aseConfig;
@@ -62,14 +62,14 @@ public class AISecurityHandlerConfig {
         this.cacheExpiryTime = cacheExpiryTime;
     }
 
-    public boolean isValidateCerts() {
+    public boolean isSkipCertValidation() {
 
-        return validateCerts;
+        return skipCertValidation;
     }
 
-    public void setValidateCerts(boolean validateCerts) {
+    public void setSkipCertValidation(boolean skipCertValidation) {
 
-        this.validateCerts = validateCerts;
+        this.skipCertValidation = skipCertValidation;
     }
 
     public AISecurityHandlerConfig.AseConfig getAseConfig() {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/async/AsyncPublishingAgent.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/async/AsyncPublishingAgent.java
@@ -85,7 +85,7 @@ public class AsyncPublishingAgent implements Runnable {
             startTenantFlow();
             if (AISecurityHandlerConstants.ASYNC_MODE_STRING.equals(operationMode)){
                 try {
-                    SecurityUtils.verifyASEResponse(aseResponseCode, correlationID);
+                    SecurityUtils.verifyASEResponse(aseResponseCode, correlationID, "Async Publisher");
                     SecurityUtils.verifyPropertiesWithCache(requestBody, correlationID);
                 } catch (AISecurityException e) {
                     //In Async mode, only a blacklist will be maintained.

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/hybrid/HybridPublisher.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/hybrid/HybridPublisher.java
@@ -74,7 +74,7 @@ public class HybridPublisher implements Publisher {
                     AISecurityHandlerConstants.ASE_RESOURCE_REQUEST);
             throw e;
         }
-        SecurityUtils.verifyASEResponse(aseResponseCode, correlationID); //For the sync response
+        SecurityUtils.verifyASEResponse(aseResponseCode, correlationID, "Sync Publisher"); //For the sync response
         return true;
     }
 

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/sync/SyncPublisher.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/sync/SyncPublisher.java
@@ -100,7 +100,7 @@ public class SyncPublisher implements Publisher {
     public boolean verifyRequest(JSONObject requestMetaData, String correlationID) throws AISecurityException {
         int aseResponseCode = publishSyncEvent(requestMetaData, correlationID,
                 AISecurityHandlerConstants.ASE_RESOURCE_REQUEST);
-        SecurityUtils.verifyASEResponse(aseResponseCode, correlationID);
+        SecurityUtils.verifyASEResponse(aseResponseCode, correlationID, "Sync Publisher");
         return true;
     }
 

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
@@ -88,6 +88,7 @@ public class AISecurityHandlerConstants {
     static final String OPERATION_MODE_CONFIGURATION = "OperationMode";
     static final String CACHE_EXPIRY_TIME_CONFIG = "CacheExpiryTime";
     static final String APPLY_FOR_ALL_APIS_CONFIG = "ApplyForAllAPIs";
+    static final String VALIDATE_CERTS_CONFIG = "ValidateCerts";
     static final String API_SECURITY_ENFORCER_CONFIGURATION = "APISecurityEnforcer";
     static final String END_POINT_CONFIGURATION = "EndPoint";
     static final String BACKUP_ASE_END_POINT_CONFIGURATION = "BackupEndPoint";

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
@@ -88,7 +88,7 @@ public class AISecurityHandlerConstants {
     static final String OPERATION_MODE_CONFIGURATION = "OperationMode";
     static final String CACHE_EXPIRY_TIME_CONFIG = "CacheExpiryTime";
     static final String APPLY_FOR_ALL_APIS_CONFIG = "ApplyForAllAPIs";
-    static final String VALIDATE_CERTS_CONFIG = "ValidateCerts";
+    static final String SKIP_CERT_VALIDATION_CONFIG = "SkipCertValidation";
     static final String API_SECURITY_ENFORCER_CONFIGURATION = "APISecurityEnforcer";
     static final String END_POINT_CONFIGURATION = "EndPoint";
     static final String BACKUP_ASE_END_POINT_CONFIGURATION = "BackupEndPoint";

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
@@ -157,6 +157,16 @@ public class SecurityHandlerConfiguration {
                         + securityHandlerConfig.isApplyForAllAPIs());
             }
 
+            // Get Validate Certificates
+            OMElement validateCertsElement = aiSecurityConfigurationElement
+                    .getFirstChildWithName(new QName(AISecurityHandlerConstants.VALIDATE_CERTS_CONFIG));
+            if (validateCertsElement != null) {
+                securityHandlerConfig.setValidateCerts(JavaUtils.isTrueExplicitly(validateCertsElement.getText()));
+            } else {
+                log.debug("Validate Certificates Element is not set. Set to default: "
+                        + securityHandlerConfig.isValidateCerts());
+            }
+
             // Get ASE config data
             OMElement aseConfigElement = aiSecurityConfigurationElement
                     .getFirstChildWithName(new QName(AISecurityHandlerConstants.API_SECURITY_ENFORCER_CONFIGURATION));

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
@@ -157,14 +157,14 @@ public class SecurityHandlerConfiguration {
                         + securityHandlerConfig.isApplyForAllAPIs());
             }
 
-            // Get Validate Certificates
-            OMElement validateCertsElement = aiSecurityConfigurationElement
-                    .getFirstChildWithName(new QName(AISecurityHandlerConstants.VALIDATE_CERTS_CONFIG));
-            if (validateCertsElement != null) {
-                securityHandlerConfig.setValidateCerts(JavaUtils.isTrueExplicitly(validateCertsElement.getText()));
+            // Get skip certificate validation
+            OMElement skipCertValifationElement = aiSecurityConfigurationElement
+                    .getFirstChildWithName(new QName(AISecurityHandlerConstants.SKIP_CERT_VALIDATION_CONFIG));
+            if (skipCertValifationElement != null) {
+                securityHandlerConfig.setSkipCertValidation(JavaUtils.isTrueExplicitly(skipCertValifationElement.getText()));
             } else {
-                log.debug("Validate Certificates Element is not set. Set to default: "
-                        + securityHandlerConfig.isValidateCerts());
+                log.debug("Skip Certificate Validation Element is not set. Set to default: "
+                        + securityHandlerConfig.isSkipCertValidation());
             }
 
             // Get ASE config data

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -189,14 +189,8 @@ public class SecurityUtils {
             throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException,
             KeyManagementException {
         SSLContext sslContext;
-        if (ServiceReferenceHolder.getInstance().getSecurityHandlerConfig().isValidateCerts()) {
-            String keyStorePath = CarbonUtils.getServerConfiguration().getFirstProperty("Security.TrustStore.Location");
-            String keyStorePassword = CarbonUtils.getServerConfiguration().getFirstProperty("Security.TrustStore.Password");
-            KeyStore trustStore = KeyStore.getInstance("JKS");
-            trustStore.load(new FileInputStream(keyStorePath), keyStorePassword.toCharArray());
-            sslContext = SSLContexts.custom().loadTrustMaterial(trustStore).build();
-        } else {
-            //If validate for cert is false, certificates will be trusted without a validation
+        if (ServiceReferenceHolder.getInstance().getSecurityHandlerConfig().isSkipCertValidation()) {
+            //If skip validation is enabled, certificates will be trusted without a validation
             sslContext = SSLContexts.custom().loadTrustMaterial(null, new TrustStrategy() {
                 @Override
                 public boolean isTrusted(X509Certificate[] chain, String authType)
@@ -204,6 +198,12 @@ public class SecurityUtils {
                     return true;
                 }
             }).build();
+        } else {
+            String keyStorePath = CarbonUtils.getServerConfiguration().getFirstProperty("Security.TrustStore.Location");
+            String keyStorePassword = CarbonUtils.getServerConfiguration().getFirstProperty("Security.TrustStore.Password");
+            KeyStore trustStore = KeyStore.getInstance("JKS");
+            trustStore.load(new FileInputStream(keyStorePath), keyStorePassword.toCharArray());
+            sslContext = SSLContexts.custom().loadTrustMaterial(trustStore).build();
         }
 
         X509HostnameVerifier hostnameVerifier;

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -353,13 +353,17 @@ public class SecurityUtils {
                                                   String correlationID) throws AISecurityException {
 
         String property = (String) requestMetaData.get(propertyName);
+        boolean status = true;
         int aseResponseForProperty = ASEResponseStore.getFromASEResponseCache(cacheName, property);
         if (aseResponseForProperty == 0) {
-            return false;
+            status = false;
         } else {
-            verifyASEResponse(aseResponseForProperty, correlationID);
+            verifyASEResponse(aseResponseForProperty, correlationID, cacheName + " Cache");
         }
-        return true;
+        if (log.isDebugEnabled()) {
+            log.debug("Status of" + cacheName + " cache  for request " + correlationID + " is " + status);
+        }
+        return status;
     }
 
     /**
@@ -369,12 +373,13 @@ public class SecurityUtils {
      * @param correlationID - Correlation ID of the request
      * @throws AISecurityException if the ASE response is to block the request
      */
-    public static void verifyASEResponse(int aseResponseCode, String correlationID)
+    public static void verifyASEResponse(int aseResponseCode, String correlationID, String instance)
             throws AISecurityException {
         //Handler will block the request only if ASE responds with forbidden code
         if (AISecurityHandlerConstants.ASE_RESPONSE_CODE_FORBIDDEN == aseResponseCode) {
             if (log.isDebugEnabled()) {
-                log.debug("Access revoked by the Ping AI handler for the request id " + correlationID);
+                log.debug("Access revoked by the Ping AI handler for the request id " + correlationID + " from " +
+                        instance);
             }
             throw new AISecurityException(AISecurityException.ACCESS_REVOKED,
                     AISecurityException.ACCESS_REVOKED_MESSAGE);


### PR DESCRIPTION
With this PR following changes were done.

1.  Added the support to disable certificate validation
2. Changed the ASE payload when the username is not available
3. Added few debug messages

### Added the support to disable certificate validation
With a configuration, certificate validation of both ASE and Management endpoint can be disabled and the endpoint will be trusted without a certificate validation.

### Changed the ASE payload when the username is not available
For unauthenticated resources, the username is set as anonymous and this leads to errors in the AI engine. Therefore if the resource is unauthenticated, user info field will not be sent to the ASE.
