### PR TITLE
Handled port in x-forwarded-for header when extracting the IP address

### DIFF
--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -248,6 +248,9 @@ public class SecurityUtils {
         } else {
             remoteIP = (String) axis2MessageContext.getProperty(org.apache.axis2.context.MessageContext.REMOTE_ADDR);
         }
+        if (remoteIP.indexOf(":") > 0) {
+            remoteIP = remoteIP.substring(0, remoteIP.indexOf(":"));
+        }
         return remoteIP;
     }
 


### PR DESCRIPTION
x-forwarded-for header can contain the port optionally and this PR removes the port from the IP. If IP contained the port, this payload will be rejected from the ASE with an incorrect JSON format error (400 error code)