### PR TITLE
Added support to change API JSON based on resource security

### DIFF
--- a/DEVELOPER_GUIDE_NEW.md
+++ b/DEVELOPER_GUIDE_NEW.md
@@ -153,7 +153,7 @@ Following configurations are for WSO2 Api Manager 3.0.0 or newer versions. For o
 
      | Dependency                |   APIM 3.2.0-beta|  APIM 3.1.0   |  APIM 3.0.0   |  
      | ------------------------- | :---------------:| :-----------: | :-----------: | 
-     | org.wso2.carbon.apimgt    |    6.7.78        |    6.6.163    |    6.5.349     | 
+     | org.wso2.carbon.apimgt    |    6.7.78        |    6.6.163    |    6.5.349    | 
 
 2. Add the JAR file of the extension to the **<APIM_HOME>/repository/components/dropins** directory.
    You can find the org.wso2.carbon.apimgt.securityenforcer-\<version>.jar file in the **apim-handler-pingai/target** directory.

--- a/DEVELOPER_GUIDE_NEW.md
+++ b/DEVELOPER_GUIDE_NEW.md
@@ -151,9 +151,9 @@ Following configurations are for WSO2 Api Manager 3.0.0 or newer versions. For o
 
     Use the following table to update pom.xml with the corresponding dependency versions for API manager.
 
-     | Dependency                |   APIM 3.0.0   |  APIM 2.6.0   |  APIM 2.5.0   |  APIM 2.2.0   |  APIM 2.1.0   |
-     | ------------------------- | :------------: | :-----------: | :-----------: | :-----------: | :-----------: |
-     | org.wso2.carbon.apimgt    |    6.5.349     |    6.4.50     |    6.3.95     |    6.2.201    |    6.1.66     |
+     | Dependency                |   APIM 3.2.0-beta|  APIM 3.1.0   |  APIM 3.0.0   |  
+     | ------------------------- | :---------------:| :-----------: | :-----------: | 
+     | org.wso2.carbon.apimgt    |    6.7.78        |    6.6.163    |    6.5.349     | 
 
 2. Add the JAR file of the extension to the **<APIM_HOME>/repository/components/dropins** directory.
    You can find the org.wso2.carbon.apimgt.securityenforcer-\<version>.jar file in the **apim-handler-pingai/target** directory.

--- a/DEVELOPER_GUIDE_NEW.md
+++ b/DEVELOPER_GUIDE_NEW.md
@@ -51,8 +51,8 @@ If the response of ASE is 200 OK, the Ping AI Security Handler forwards the requ
 3. ASE logs metadata and checks the following.
     - Checks if it is an unregistered API, format error, or bad Auth token.
         - If yes, return specified code.
-    - Checks if the origin IP/Cookie/API Key/OAuth Token is on the blacklist.
-        - If on the blacklist, returns **403**.
+    - Checks if the origin IP/Cookie/API Key/OAuth Token is on the block list.
+        - If on the block list, returns **403**.
     - Otherwise, returns **200-OK**.
 4. WSO2 API Gateway receives the ASE response:
     - If the response is **200-OK**, it sends the API request to the App server.

--- a/DEVELOPER_GUIDE_OLD.md
+++ b/DEVELOPER_GUIDE_OLD.md
@@ -51,8 +51,8 @@ If the response of ASE is 200 OK, the Ping AI Security Handler forwards the requ
 3. ASE logs metadata and checks the following.
     - Checks if it is an unregistered API, format error, or bad Auth token.
         - If yes, return specified code.
-    - Checks if the origin IP/Cookie/API Key/OAuth Token is on the blacklist.
-        - If on the blacklist, returns **403**.
+    - Checks if the origin IP/Cookie/API Key/OAuth Token is on the block list.
+        - If on the block list, returns **403**.
     - Otherwise, returns **200-OK**.
 4. WSO2 API Gateway receives the ASE response:
     - If the response is **200-OK**, it sends the API request to the App server.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>6.6.163 </version>
+        <version>6.6.163</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>6.5.349</version>
+        <version>6.6.163 </version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/PingAISecurityHandler.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/PingAISecurityHandler.java
@@ -185,8 +185,12 @@ public class PingAISecurityHandler extends AbstractHandler {
             }
         }
         String cookie = SecurityUtils.getCookie(transportHeadersMap);
+        String hashedCookie = "";
         if (cookie != null) {
             cookie = SecurityUtils.anonymizeCookie(cookie);
+            transportHeaders.add(SecurityUtils.addObj(AISecurityHandlerConstants.COOKIE_KEY_NAME, cookie));
+            //This cookieHash is used as the key of cookie cache
+            hashedCookie = DigestUtils.md5Hex(cookie);
         }
         String requestOriginIP = SecurityUtils.getIp(axis2MessageContext);
         int requestOriginPort = AISecurityHandlerConstants.DUMMY_REQUEST_PORT;
@@ -210,7 +214,7 @@ public class PingAISecurityHandler extends AbstractHandler {
 
         JSONObject requestPayload = new JSONObject();
         requestPayload.put(AISecurityHandlerConstants.ASE_PAYLOAD_KEY_NAME, asePayload);
-        requestPayload.put(AISecurityHandlerConstants.COOKIE_KEY_NAME, cookie);
+        requestPayload.put(AISecurityHandlerConstants.COOKIE_KEY_NAME, hashedCookie);
         requestPayload.put(AISecurityHandlerConstants.IP_KEY_NAME, requestOriginIP);
         requestPayload.put(AISecurityHandlerConstants.TOKEN_KEY_NAME, hashedToken);
         return requestPayload;

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/async/AsyncPublishingAgent.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/async/AsyncPublishingAgent.java
@@ -88,11 +88,11 @@ public class AsyncPublishingAgent implements Runnable {
                     SecurityUtils.verifyASEResponse(aseResponseCode, correlationID, "Async Publisher");
                     SecurityUtils.verifyPropertiesWithCache(requestBody, correlationID);
                 } catch (AISecurityException e) {
-                    //In Async mode, only a blacklist will be maintained.
+                    //In Async mode, only a block list will be maintained.
                     ASEResponseStore.updateCache(requestBody, aseResponseCode, correlationID);
                 }
             } else {
-                //In Hybrid mode, both black and white lists will be maintained
+                //In Hybrid mode, both block and allow lists will be maintained
                 ASEResponseStore.updateCache(requestBody, aseResponseCode, correlationID);
             }
             if (tenantFlowStarted) {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
@@ -34,6 +34,7 @@ public class AISecurityHandlerConstants {
     public static final String JSON_KEY_HEADERS = "headers";
     public static final String JSON_KEY_USER_INFO = "user_info";
     public static final String JSON_KEY_USER_NAME = "username";
+    public static final String JSON_KEY_CLIENT_ID = "client_id";
     public static final String JSON_KEY_RESPONSE_CODE = "response_code";
     public static final String JSON_KEY_RESPONSE_STATUS = "response_status";
     public static final String ASE_RESOURCE_REQUEST = "request";

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
@@ -31,10 +31,11 @@ import org.wso2.securevault.SecretResolverFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.Stack;
+import java.util.TreeSet;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
@@ -359,11 +360,11 @@ public class SecurityHandlerConfiguration {
 
                 Iterator headersIterator = limitTransportHeadersElement
                         .getChildrenWithLocalName(AISecurityHandlerConstants.HEADER_CONFIGURATION);
-                Set<String> headerSet = new HashSet<>();
+                Set<String> headerSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
                 while (headersIterator.hasNext()) {
                     OMElement headerElement = (OMElement) headersIterator.next();
                     if (headerElement != null) {
-                        headerSet.add(headerElement.getText().toLowerCase());
+                        headerSet.add(headerElement.getText());
                     }
                 }
                 limitTransportHeadersConfig.setHeaderSet(headerSet);

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -23,6 +23,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
 import org.apache.axis2.Constants;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.ProtocolVersion;
@@ -387,5 +388,34 @@ public class SecurityUtils {
             throw new AISecurityException(AISecurityException.ACCESS_REVOKED,
                     AISecurityException.ACCESS_REVOKED_MESSAGE);
         }
+    }
+
+    /**
+     * This method will anonymize the cookie content by hashing with md5
+     *
+     * @param cookieString - Cookie header value
+     */
+    public static String anonymizeCookie(String cookieString) {
+
+        String finalString = "";
+        if (cookieString.isEmpty()) {
+            return null;
+        } else {
+            String[] cookieVariables = cookieString.split(";");
+
+            for (String cookieVariable : cookieVariables) {
+                String[] keyValuePair = cookieVariable.split("=");
+                if (keyValuePair.length > 1) {
+                    finalString = finalString + keyValuePair[0] + "=" + DigestUtils.md5Hex(keyValuePair[1]) + ";";
+                } else {
+                    finalString = finalString + DigestUtils.md5Hex(cookieVariable) + ";";
+                }
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Cookie header values were anonymized");
+        }
+        return finalString;
     }
 }

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -56,9 +56,10 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
@@ -83,7 +84,10 @@ public class SecurityUtils {
 
         if (transportHeadersMap != null) {
             JSONArray transportHeadersArray = new JSONArray();
-            Set<String> headerKeysSet = new HashSet<String>(transportHeadersMap.keySet());
+            Set<String> headerKeysSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+            headerKeysSet.addAll(transportHeadersMap.keySet());
+            headerKeysSet.remove(AISecurityHandlerConstants.AUTHORIZATION);
+            headerKeysSet.remove(AISecurityHandlerConstants.COOKIE_KEY_NAME);
 
             if (log.isDebugEnabled()) {
                 log.debug("Transport headers found for the request " + correlationID + " are " + headerKeysSet);
@@ -106,7 +110,7 @@ public class SecurityUtils {
             if (limitTransportHeadersConfig.isEnable()) {
                 Set<String> allowedTransportHeadersKeySet = limitTransportHeadersConfig.getHeaderSet();
                 for (String headerKey : headerKeysSet) {
-                    if (allowedTransportHeadersKeySet.contains(headerKey.toLowerCase())) {
+                    if (allowedTransportHeadersKeySet.contains(headerKey)) {
                         String headerValue = transportHeadersMap.get(headerKey);
                         transportHeadersArray.add(addObj(headerKey, headerValue));
                     }

--- a/src/test/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtilsTest.java
+++ b/src/test/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtilsTest.java
@@ -27,9 +27,9 @@ import org.wso2.carbon.apimgt.securityenforcer.dto.AISecurityHandlerConfig;
 import org.wso2.carbon.apimgt.securityenforcer.internal.ServiceReferenceHolder;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 public class SecurityUtilsTest {
 
@@ -59,7 +59,7 @@ public class SecurityUtilsTest {
 
         AISecurityHandlerConfig securityHandlerConfig = new AISecurityHandlerConfig();
         AISecurityHandlerConfig.LimitTransportHeaders limitTransportHeadersConfig = new AISecurityHandlerConfig.LimitTransportHeaders();
-        Set limitTransportHeaderSet = new HashSet();
+        Set limitTransportHeaderSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         limitTransportHeaderSet.add(headerOne.toLowerCase());
         limitTransportHeaderSet.add(headerTwo.toLowerCase());
         limitTransportHeadersConfig.setEnable(true);
@@ -85,7 +85,7 @@ public class SecurityUtilsTest {
 
         AISecurityHandlerConfig securityHandlerConfig = new AISecurityHandlerConfig();
         AISecurityHandlerConfig.LimitTransportHeaders limitTransportHeadersConfig = new AISecurityHandlerConfig.LimitTransportHeaders();
-        Set limitTransportHeaderSet = new HashSet();
+        Set limitTransportHeaderSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         limitTransportHeaderSet.add(headerOne.toLowerCase());
         limitTransportHeaderSet.add(headerTwo.toLowerCase());
         limitTransportHeadersConfig.setEnable(true);
@@ -110,7 +110,7 @@ public class SecurityUtilsTest {
 
         AISecurityHandlerConfig securityHandlerConfig = new AISecurityHandlerConfig();
         AISecurityHandlerConfig.LimitTransportHeaders limitTransportHeadersConfig = new AISecurityHandlerConfig.LimitTransportHeaders();
-        Set limitTransportHeaderSet = new HashSet();
+        Set limitTransportHeaderSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         limitTransportHeaderSet.add(headerOne.toLowerCase());
         limitTransportHeaderSet.add(headerTwo.toLowerCase());
         limitTransportHeaderSet.add(headerFive.toLowerCase());
@@ -135,7 +135,7 @@ public class SecurityUtilsTest {
 
         AISecurityHandlerConfig securityHandlerConfig = new AISecurityHandlerConfig();
         AISecurityHandlerConfig.LimitTransportHeaders limitTransportHeadersConfig = new AISecurityHandlerConfig.LimitTransportHeaders();
-        Set limitTransportHeaderSet = new HashSet();
+        Set limitTransportHeaderSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         limitTransportHeaderSet.add(headerOne.toLowerCase());
         limitTransportHeaderSet.add(headerTwo.toLowerCase());
         limitTransportHeaderSet.add(headerFive.toLowerCase());
@@ -158,7 +158,7 @@ public class SecurityUtilsTest {
 
         AISecurityHandlerConfig securityHandlerConfig = new AISecurityHandlerConfig();
         AISecurityHandlerConfig.LimitTransportHeaders limitTransportHeadersConfig = new AISecurityHandlerConfig.LimitTransportHeaders();
-        Set limitTransportHeaderSet = new HashSet();
+        Set limitTransportHeaderSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         limitTransportHeaderSet.add(headerOne.toLowerCase());
         limitTransportHeaderSet.add(headerTwo.toLowerCase());
         limitTransportHeaderSet.add(hostHeader.toLowerCase());
@@ -184,7 +184,7 @@ public class SecurityUtilsTest {
 
         AISecurityHandlerConfig securityHandlerConfig = new AISecurityHandlerConfig();
         AISecurityHandlerConfig.LimitTransportHeaders limitTransportHeadersConfig = new AISecurityHandlerConfig.LimitTransportHeaders();
-        Set limitTransportHeaderSet = new HashSet();
+        Set limitTransportHeaderSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         limitTransportHeaderSet.add(headerOne.toLowerCase());
         limitTransportHeaderSet.add(headerTwo.toLowerCase());
         limitTransportHeaderSet.add(headerFive.toLowerCase());


### PR DESCRIPTION
With this PR,

1.  Added support to change API JSON of ASE based on the API security configurations.
2. Anonymized the cookie content before sending it to ASE.
3. Removed blacklist, whitelist references from the documentation.
4. Bumped the carbon.apimgt.version to the latest.

