### PR TITLE
Changed defaults and fixed few bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ target/test-classes/*
 *Test.txt
 *Test.xml
 target/classes/org/wso2/carbon/apimgt/securityenforcer/internal/samplePingAIManagementPayload.json
+target/classes/META-INF/*
+target/maven-shared-archive-resources/*
+target/.plxarc

--- a/DEVELOPER_GUIDE_NEW.md
+++ b/DEVELOPER_GUIDE_NEW.md
@@ -367,7 +367,7 @@ There is a new model created in the security engine for every API deployed with 
             "apikey_qs": "",
             "apikey_header": "",
             "login_url": "",
-            "enable_blocking": true,
+            "enable_blocking": false,
             "api_memory_size": "128mb",
             "server_ssl": false,
             "decoy_config": {

--- a/DEVELOPER_GUIDE_OLD.md
+++ b/DEVELOPER_GUIDE_OLD.md
@@ -354,7 +354,7 @@ There is a new model created in the security engine for every API deployed with 
             "apikey_qs": "",
             "apikey_header": "",
             "login_url": "",
-            "enable_blocking": true,
+            "enable_blocking": false,
             "api_memory_size": "128mb",
             "server_ssl": false,
             "decoy_config": {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/executors/PingAIExecutor.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/executors/PingAIExecutor.java
@@ -185,8 +185,9 @@ public class PingAIExecutor implements Execution {
                                 "application/json");
                         postRequest.setEntity(new StringEntity(requestBody.toString().replaceAll("\\\\", "")));
 
-                        responseStatus = httpDataPublisher.publishToASEManagementAPI(AISecurityHandlerConstants.CREATE,
-                                postRequest);
+                        responseStatus = httpDataPublisher.publishToASEManagementAPI(
+                                securityHandlerConfig.getModelCreationEndpointConfig().getManagementAPIEndpoint(),
+                                AISecurityHandlerConstants.CREATE, postRequest);
                     }
                     if (AISecurityHandlerConstants.RETIRED.equals(targetState.toUpperCase())) {
                         HttpDelete deleteRequest = new HttpDelete(managementAPIEndpoint + "?api_id=" + modelName);
@@ -197,8 +198,9 @@ public class PingAIExecutor implements Execution {
                         deleteRequest.addHeader(AISecurityHandlerConstants.ASE_MANAGEMENT_HEADER_CONTENT_TYPE,
                                 "application/json");
 
-                        responseStatus = httpDataPublisher.publishToASEManagementAPI(AISecurityHandlerConstants.DELETE,
-                                deleteRequest);
+                        responseStatus = httpDataPublisher.publishToASEManagementAPI(
+                                securityHandlerConfig.getModelCreationEndpointConfig().getManagementAPIEndpoint(),
+                                AISecurityHandlerConstants.DELETE, deleteRequest);
                     }
 
                     if (responseStatus != null) {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/executors/PingAIExecutor.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/executors/PingAIExecutor.java
@@ -124,14 +124,18 @@ public class PingAIExecutor implements Execution {
                     try {
                         API api = APIUtil.getAPI(apiArtifact);
                         Set<URITemplate> resourceTemplates = api.getUriTemplates();
+                        int resourceTemplatesSetSize = resourceTemplates.size();
+                        int noneTypeResources = 0;
                         for (URITemplate resource : resourceTemplates) {
                             String authType = resource.getAuthType();
                             if ("None".equals(authType)) {
-                                isAPIAuthenticated = false;
-                                if (log.isDebugEnabled()) {
-                                    log.debug("UnAuthenticated resource found for API " + apiName);
-                                }
-                                break;
+                                noneTypeResources++;
+                            }
+                        }
+                        if (noneTypeResources > resourceTemplatesSetSize-noneTypeResources) {
+                            isAPIAuthenticated = false;
+                            if (log.isDebugEnabled()) {
+                                log.debug("None type resources are more than authenticated resources for API " + apiName);
                             }
                         }
                     } catch (APIManagementException e) {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/internal/PingAIHandlerComponent.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/internal/PingAIHandlerComponent.java
@@ -101,11 +101,9 @@ public class PingAIHandlerComponent implements BundleActivator {
             AISecurityHandlerConfig.AseConfig aseConfiguration = securityHandlerConfig.getAseConfig();
             AISecurityHandlerConfig.DataPublisherConfig dataPublisherConfiguration = securityHandlerConfig
                     .getDataPublisherConfig();
-            AISecurityHandlerConfig.ModelCreationEndpoint modelCreationConfiguration = securityHandlerConfig
-                    .getModelCreationEndpointConfig();
 
             try {
-                httpDataPublisher = new HttpDataPublisher(aseConfiguration, dataPublisherConfiguration, modelCreationConfiguration);
+                httpDataPublisher = new HttpDataPublisher(aseConfiguration, dataPublisherConfiguration);
             } catch (AISecurityException e) {
                 log.error("Error when creating a httpDataPublisher Instance " + e.getMessage());
                 throw new Exception(e);

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/internal/PingAIHandlerComponent.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/internal/PingAIHandlerComponent.java
@@ -101,9 +101,11 @@ public class PingAIHandlerComponent implements BundleActivator {
             AISecurityHandlerConfig.AseConfig aseConfiguration = securityHandlerConfig.getAseConfig();
             AISecurityHandlerConfig.DataPublisherConfig dataPublisherConfiguration = securityHandlerConfig
                     .getDataPublisherConfig();
+            AISecurityHandlerConfig.ModelCreationEndpoint modelCreationConfiguration = securityHandlerConfig
+                    .getModelCreationEndpointConfig();
 
             try {
-                httpDataPublisher = new HttpDataPublisher(aseConfiguration, dataPublisherConfiguration);
+                httpDataPublisher = new HttpDataPublisher(aseConfiguration, dataPublisherConfiguration, modelCreationConfiguration);
             } catch (AISecurityException e) {
                 log.error("Error when creating a httpDataPublisher Instance " + e.getMessage());
                 throw new Exception(e);

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/HttpDataPublisher.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/HttpDataPublisher.java
@@ -33,7 +33,6 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.json.simple.JSONObject;
-import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.securityenforcer.dto.AISecurityHandlerConfig;
 import org.wso2.carbon.apimgt.securityenforcer.utils.AISecurityException;
 import org.wso2.carbon.apimgt.securityenforcer.utils.AISecurityHandlerConstants;
@@ -152,8 +151,8 @@ public class HttpDataPublisher {
         try {
             aseManagementEndpointPort = new URL(modelCreationEndpoint).getPort();
             aseManagementEndpointProtocol = new URL(modelCreationEndpoint).getProtocol();
-            HttpClient aseManagementEndpointHttpClient = APIUtil.getHttpClient(aseManagementEndpointPort,
-                    aseManagementEndpointProtocol);
+            HttpClient aseManagementEndpointHttpClient = SecurityUtils
+                    .getManagementHttpClient(aseManagementEndpointPort, aseManagementEndpointProtocol);
 
             if (AISecurityHandlerConstants.CREATE.equals(type)) {
                 HttpPost postRequest = (HttpPost) request;

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/HttpDataPublisher.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/HttpDataPublisher.java
@@ -154,6 +154,11 @@ public class HttpDataPublisher {
             HttpClient aseManagementEndpointHttpClient = SecurityUtils
                     .getManagementHttpClient(aseManagementEndpointPort, aseManagementEndpointProtocol);
 
+            if (aseManagementEndpointHttpClient == null) {
+                log.error("Error occurred while publishing " + type + " request to ASE Management API");
+                return null;
+            }
+
             if (AISecurityHandlerConstants.CREATE.equals(type)) {
                 HttpPost postRequest = (HttpPost) request;
                 response = aseManagementEndpointHttpClient.execute(postRequest);

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -418,6 +418,10 @@ public class SecurityUtils {
         if (log.isDebugEnabled()) {
             log.debug("Cookie header values were anonymized");
         }
-        return finalString;
+        
+        if (finalString == null || finalString.length() == 0) {
+            return finalString;
+        }
+        return finalString.substring(0, finalString.length() - 1);
     }
 }

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityUtils.java
@@ -463,6 +463,9 @@ public class SecurityUtils {
         if (APIConstants.HTTPS_PROTOCOL.equals(protocol)) {
             try {
                 socketFactory = createManagementSocketFactory();
+                if (socketFactory == null) {
+                    return null;
+                }
                 socketFactory.setHostnameVerifier(hostnameVerifier);
                 if (port >= 0) {
                     registry.register(new Scheme(APIConstants.HTTPS_PROTOCOL, port, socketFactory));

--- a/src/main/resources/org/wso2/carbon/apimgt/securityenforcer/internal/samplePingAIManagementPayload.json
+++ b/src/main/resources/org/wso2/carbon/apimgt/securityenforcer/internal/samplePingAIManagementPayload.json
@@ -11,7 +11,7 @@
     "apikey_qs": "",
     "apikey_header": "",
     "login_url": "",
-    "enable_blocking": true,
+    "enable_blocking": false,
     "api_memory_size": "128mb",
     "server_ssl": false,
     "decoy_config": {


### PR DESCRIPTION
**Change summary:**
1. Changed default of enable_blocking to false in ASE API json
2. Bug fix - when ase data port is http and ase management port is https, APIs are not getting published in ASE
3. Escape backslashes and double quotes in ASE payload
4. Bug fix - anonymizeCookie is returning a semicolon at the end
5. oauth2_access_token property of ASE API json will be set to false only if number of **None** type resources are greater than number of other resources.
