### PR TITLE
Changed logic to handle shifting ASE endpoints in case of connection or read timeouts

### DIFF
--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
@@ -131,26 +131,27 @@ public class AISecurityHandlerConfig {
 
     public static class AseConfig {
 
-        private String endPoint;
+        private String primaryAseEndPoint;
         private String backupAseEndPoint;
-        private Boolean shift = false;
+        private String currentEndpoint;
 
         private String aseToken;
-        private String backupAseToken;
 
         public String getEndPoint() {
-            if (!shift) {
-                return endPoint;
-            }
-            return backupAseEndPoint;
+            return currentEndpoint;
         }
 
         public void setEndPoint(String endPoint) {
-            this.endPoint = endPoint;
+            this.primaryAseEndPoint = endPoint;
+            this.currentEndpoint = endPoint;
         }
 
-        public void shiftEndpoint() {
-            this.shift = !this.shift;
+        public synchronized void shiftEndpoint(String currEndpoint) {
+            if (currEndpoint.equalsIgnoreCase(primaryAseEndPoint)) {
+                this.currentEndpoint = backupAseEndPoint;
+            } else {
+                this.currentEndpoint = primaryAseEndPoint;
+            }
         }
 
         public String getBackupAseEndPoint() {
@@ -162,18 +163,11 @@ public class AISecurityHandlerConfig {
         }
 
         public String getAseToken() {
-            if (!shift) {
-                return aseToken;
-            }
-            return backupAseToken;
+            return aseToken;
         }
 
         public void setAseToken(String aseToken) {
             this.aseToken = aseToken;
-        }
-
-        public void setBackupAseToken(String backupAseToken) {
-            this.backupAseToken = backupAseToken;
         }
     }
 

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/dto/AISecurityHandlerConfig.java
@@ -133,6 +133,8 @@ public class AISecurityHandlerConfig {
 
         private String primaryAseEndPoint;
         private String backupAseEndPoint;
+        // currentEndpoint is the ASE endpoint to which AISecurityHandler will send the
+        // requests to at any point of time.
         private String currentEndpoint;
 
         private String aseToken;
@@ -141,11 +143,23 @@ public class AISecurityHandlerConfig {
             return currentEndpoint;
         }
 
+        /**
+         * This method is called only once when the AISecurityHandler configuration is
+         * loaded. It will set the primaryAseEndPoint and currentEndpoint.
+         */
         public void setEndPoint(String endPoint) {
             this.primaryAseEndPoint = endPoint;
             this.currentEndpoint = endPoint;
         }
 
+        /**
+         * This method takes currEndpoint as an argument that has resulted in a
+         * connection refused or connection timeout exception. If shiftEndpoint receives
+         * primaryAseEndPoint as argument, currentEndpoint will be set to
+         * backupAseEndPoint. If shiftEndpoint receives backupAseEndPoint as argument,
+         * currentEndpoint will be set to primaryAseEndPoint. This method is thread safe
+         * since it is synchronized.
+         */
         public synchronized void shiftEndpoint(String currEndpoint) {
             if (currEndpoint.equalsIgnoreCase(primaryAseEndPoint)) {
                 this.currentEndpoint = backupAseEndPoint;

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/HttpDataPublisher.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/publisher/HttpDataPublisher.java
@@ -75,6 +75,7 @@ public class HttpDataPublisher {
     }
 
     public int publish(JSONObject data, String correlationID, String resource) {
+        String localEndPoint = endPoint;
         HttpPost postRequest = new HttpPost(endPoint + "/ase/" + resource);
         postRequest.addHeader(AISecurityHandlerConstants.ASE_TOKEN_HEADER, authToken);
         postRequest.addHeader(AISecurityHandlerConstants.X_CORRELATION_ID_HEADER, correlationID);
@@ -126,10 +127,9 @@ public class HttpDataPublisher {
                 log.error("Null response returned from ASE for the request " + correlationID);
             }
         } catch (Exception ex) {
-            aseConfig.shiftEndpoint();
-            endPoint = aseConfig.getEndPoint();
-            setEndPoint(aseConfig.getEndPoint());
             log.error("Error sending the HTTP Request with id " + correlationID, ex);
+            aseConfig.shiftEndpoint(localEndPoint);
+            endPoint = aseConfig.getEndPoint();
         } finally {
             if (response != null) {
                 try {

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/AISecurityHandlerConstants.java
@@ -94,7 +94,6 @@ public class AISecurityHandlerConstants {
     static final String END_POINT_CONFIGURATION = "EndPoint";
     static final String BACKUP_ASE_END_POINT_CONFIGURATION = "BackupEndPoint";
     static final String ASE_TOKEN_CONFIGURATION = "ASEToken";
-    static final String BACKUP_ASE_TOKEN_CONFIGURATION = "BackupASEToken";
     static final String MODEL_CREATION_ENDPOINT_CONFIGURATION = "ModelCreationEndpoint";
     static final String ACCESS_KEY_CONFIGURATION = "AccessKey";
     static final String SECRET_KEY_CONFIGURATION = "SecretKey";

--- a/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
+++ b/src/main/java/org/wso2/carbon/apimgt/securityenforcer/utils/SecurityHandlerConfiguration.java
@@ -211,18 +211,6 @@ public class SecurityHandlerConfiguration {
                             AISecurityException.HANDLER_ERROR_MESSAGE);
                 }
 
-                OMElement backupAseTokenElement = aseConfigElement
-                        .getFirstChildWithName(new QName(AISecurityHandlerConstants.BACKUP_ASE_TOKEN_CONFIGURATION));
-                if (backupAseTokenElement != null) {
-                    if (secretResolver.isInitialized()
-                            && secretResolver.isTokenProtected("APIManager.AISecurityHandler.ASE.BackupASEToken")) {
-                        aseConfig.setBackupAseToken(secretResolver
-                                .resolve("APIManager.AISecurityHandler.ASE.BackupASEToken"));
-                    } else {
-                        aseConfig.setBackupAseToken(backupAseTokenElement.getText());
-                    }
-                }
-
                 OMElement modelCreationEndpointElement = aseConfigElement.getFirstChildWithName(
                         new QName(AISecurityHandlerConstants.MODEL_CREATION_ENDPOINT_CONFIGURATION));
                 AISecurityHandlerConfig.ModelCreationEndpoint modelCreationEndpointConfig = new AISecurityHandlerConfig.ModelCreationEndpoint();


### PR DESCRIPTION
1. Bug fix - In Async mode, if primary ASE is resulting in connection timeouts, shifting to secondary ASE is not working.
2. BackupAseToken is not needed. Primary and Secondary ASE's in a cluster will use the same sideband auth token.